### PR TITLE
Update the docker files to work on Macbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,5 +63,3 @@ web/src/config/Static.json
 
 subgraph/subgraph.yaml
 
-docker-compose.nash.yml
-

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ web/src/config/Static.json
 
 subgraph/subgraph.yaml
 
+docker-compose.nash.yml
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,4 +103,4 @@ services:
       - /web/node_modules
     ports:
       - "3000:3000"
-    command: npm start
+    command: ./start.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,6 @@ services:
     links:
       - ganache-cli
     command: npm run deploy:docker
-    #command: tail -f /dev/null
 
   graph-node:
     user: $UID
@@ -60,12 +59,14 @@ services:
       GRAPH_LOG: info
     extra_hosts:
       - "host.docker.internal:172.17.0.1"
+
   ipfs:
     image: ipfs/go-ipfs:v0.4.23
     ports:
       - '5001:5001'
     volumes:
       - ./data/ipfs:/data/ipfs
+
   postgres:
     image: postgres
     ports:
@@ -87,13 +88,14 @@ services:
       context: ./subgraph
     volumes:
       - ./subgraph:/subgraph
+      - /subgraph/node_modules
     links:
       - ipfs
       - graph-node
     command: ./start.sh
 
   client:
-    #user: $UID
+    user: $UID
     build:
       context: ./web
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
       - ganache-cli
     build:
       context: ./hardhat
+    environment:
+      - IS_DOCKER=true
     volumes:
       - ./hardhat:/hardhat
       - /hardhat/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,6 @@ services:
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
 
-
   subgraph-init:
     depends_on:
       - graph-node
@@ -93,7 +92,6 @@ services:
       - graph-node
     command: ./start.sh
 
-
   client:
     #user: $UID
     build:
@@ -104,4 +102,3 @@ services:
     ports:
       - "3000:3000"
     command: npm start
-    

--- a/hardhat/.env.example
+++ b/hardhat/.env.example
@@ -1,2 +1,1 @@
 MNEMONIC=<string>
-IS_DOCKER=<bool>

--- a/hardhat/Dockerfile
+++ b/hardhat/Dockerfile
@@ -3,6 +3,7 @@ FROM node:14-alpine as base
 COPY . /hardhat
 WORKDIR /hardhat
 COPY package*.json ./
+RUN apk --no-cache --virtual build-dependencies add python3 make g++ bash
 RUN npm install
 
 EXPOSE 8545

--- a/hardhat/package.json
+++ b/hardhat/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "npx hardhat test",
-    "docgen": "npx solidity-docgen --solc-module solc-0.8 -o '../docusaur/docs/API Specification' -t ../docusaur/docgen-template",
-    "deploy:docker": "npxd hardhat run ./scripts/deploy.js --network docker && npxd hardhat run ./scripts/scaffold-testnet.js --network docker"
+    "test": "hardhat test",
+    "docgen": "solidity-docgen --solc-module solc-0.8 -o '../docusaur/docs/API Specification' -t ../docusaur/docgen-template",
+    "deploy:docker": "hardhat run ./scripts/deploy.js --network docker && hardhat run ./scripts/scaffold-testnet.js --network docker"
   },
   "keywords": [],
   "author": "",

--- a/start-docker.sh
+++ b/start-docker.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-export UID
+
+if [[ "$OSTYPE" != "darwin"* ]]; then 
+  export UID
+fi
 
 IS_DOCKER=$(grep IS_DOCKER ./hardhat/.env | cut -d '=' -f 2-)
 
@@ -24,6 +27,8 @@ then
   echo 'Need sudo to remove psql and ipfs dirs for subgraph not to fail'
   sudo rm -rf $DATA_DIR
 fi
+
+rm -rf web/src/config
 
 docker-compose up
 

--- a/start-docker.sh
+++ b/start-docker.sh
@@ -25,6 +25,6 @@ then
   sudo rm -rf $DATA_DIR
 fi
 
-docker-compose -f docker-compose.dev.yml up
+docker-compose up
 
 

--- a/start-docker.sh
+++ b/start-docker.sh
@@ -4,15 +4,6 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
   export UID
 fi
 
-IS_DOCKER=$(grep IS_DOCKER ./hardhat/.env | cut -d '=' -f 2-)
-
-if [ $IS_DOCKER == "false" ]
-then
-  echo "Please set the IS_DOCKER env variable in ./hardhat to true"
-  exit 1
-fi
-
-
 SUBGRAPH_ENV=${pwd}/subgraph/.env
 
 if [ -f $SUBGRAPH_ENV ]

--- a/subgraph/start.sh
+++ b/subgraph/start.sh
@@ -16,6 +16,15 @@ do
   sleep 1
 done
 rm -rf /subgraph/.env
-npm run codegen
-npm run create-local:docker
-npm run deploy-local:docker
+npm run codegen 
+
+# Sometimes the graph-node container is not ready 
+# so we wrapped the deployment command in the following block to automatically 
+# retry on connection failure.
+RETRIES=0
+until [ "$RETRIES" -ge 5 ]
+do
+  npm run create-local:docker && npm run deploy-local:docker && break
+  RETRIES=$((RETRIES+1))
+  sleep 5
+done

--- a/web/start.sh
+++ b/web/start.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Check if smart contract deployment has finished
+FILE=./src/config/Static.json
+while [ ! -f $FILE ]
+do
+  echo "waiting for deploy script to finish"
+  sleep 5
+done
+
+# Start the development server
+npm start


### PR DESCRIPTION
The main issue is the custom UID for the docker containers. It is required to work on Linux but it will failed on my Macbook. So I updated the `start-docker.sh` script to skip the UID exports on Macbook. In addition, I added the following:

- I need to add python3 package to `hardhat/Dockerfile` to make it working on my Macbook.
- I removed the `npx` and `npxd` command in the `package.json` file. I believe the `npxd` is meant to be use from the host instead of `package.json`.
- Automatically retry subgraph deployment in case of the graph-node container is not ready to accept connections.
- Wait until the smart contract deployment is finished before running the frontend dev server.
- Moved the IS_DOCKER variable from the `.env` to the `docker-compose.yml` file so we don't need to edit the `.env` file when changing environment.

